### PR TITLE
Add Next.js project with email form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # Mobilemechanicmuscle
+
+This is a Next.js project using TypeScript and Tailwind CSS. It contains a simple form for submitting a service request. Submitted information is sent to a configured email address via a serverless API route.
+
+## Development
+
+1. Install dependencies (requires Node.js >=18):
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) to see the form.
+
+## Environment Variables
+
+Configure the following variables to enable email sending:
+
+- `EMAIL_HOST` – SMTP host
+- `EMAIL_PORT` – SMTP port
+- `EMAIL_USER` – SMTP username
+- `EMAIL_PASS` – SMTP password
+- `EMAIL_FROM` – from address
+- `EMAIL_TO` – destination address
+
+Create a `.env.local` file with these variables when running locally or set them in your Vercel project.
+
+## Deployment
+
+This project can be deployed to [Vercel](https://vercel.com/). After installing dependencies and configuring environment variables, run:
+
+```bash
+npm run build
+```
+
+Then deploy with the Vercel CLI or by connecting the repository in the Vercel dashboard.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mobilemechanicmuscle",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "5.2.2",
+    "tailwindcss": "3.3.5",
+    "postcss": "8.4.21",
+    "autoprefixer": "10.4.14",
+    "nodemailer": "6.9.4"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,8 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/api/send-form.ts
+++ b/pages/api/send-form.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nodemailer from 'nodemailer';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const { fullName, vinOrPlate, email, serviceRequest } = req.body;
+
+  if (!fullName || !vinOrPlate || !email || !serviceRequest) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.EMAIL_HOST,
+      port: Number(process.env.EMAIL_PORT || 587),
+      secure: false,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS
+      }
+    });
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: process.env.EMAIL_TO,
+      subject: 'New Service Request',
+      text: `Name: ${fullName}\nPlate: ${vinOrPlate.plateNumber} (${vinOrPlate.state})\nEmail: ${email}\nRequest: ${serviceRequest}`
+    });
+
+    res.status(200).json({ message: 'Sent' });
+  } catch (err) {
+    res.status(500).json({ message: 'Failed to send', error: String(err) });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+
+interface FormData {
+  fullName: string;
+  vinOrPlate: {
+    plateNumber: string;
+    state: string;
+  };
+  email: string;
+  serviceRequest: string;
+}
+
+export default function Home() {
+  const [formData, setFormData] = useState<FormData>({
+    fullName: '',
+    vinOrPlate: { plateNumber: '', state: '' },
+    email: '',
+    serviceRequest: ''
+  });
+  const [status, setStatus] = useState('');
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    if (name === 'plateNumber' || name === 'state') {
+      setFormData(prev => ({
+        ...prev,
+        vinOrPlate: { ...prev.vinOrPlate, [name]: value }
+      }));
+    } else {
+      setFormData(prev => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('Sending...');
+    try {
+      const res = await fetch('/api/send-form', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+      if (res.ok) {
+        setStatus('Sent successfully');
+        setFormData({
+          fullName: '',
+          vinOrPlate: { plateNumber: '', state: '' },
+          email: '',
+          serviceRequest: ''
+        });
+      } else {
+        setStatus('Failed to send');
+      }
+    } catch (err) {
+      setStatus('Failed to send');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white shadow-md rounded px-8 pt-6 pb-8 w-full max-w-md"
+      >
+        <h1 className="text-2xl mb-4 font-bold text-center">Service Request</h1>
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="fullName">
+            Full Name
+          </label>
+          <input
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="fullName"
+            name="fullName"
+            type="text"
+            value={formData.fullName}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="plateNumber">
+            Plate Number
+          </label>
+          <input
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="plateNumber"
+            name="plateNumber"
+            type="text"
+            value={formData.vinOrPlate.plateNumber}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="state">
+            State
+          </label>
+          <input
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="state"
+            name="state"
+            type="text"
+            value={formData.vinOrPlate.state}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="email">
+            Email
+          </label>
+          <input
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="serviceRequest">
+            Service Request
+          </label>
+          <textarea
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="serviceRequest"
+            name="serviceRequest"
+            value={formData.serviceRequest}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <button
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            type="submit"
+          >
+            Submit
+          </button>
+          <p className="text-sm text-gray-600" data-testid="status">
+            {status}
+          </p>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js + TypeScript app
- add Tailwind CSS
- implement form to collect service requests
- create API route that emails form data via nodemailer
- document setup and deployment steps

## Testing
- `npm install` *(fails: unable to reach registry)*